### PR TITLE
feat: startup catch-up and health watchdog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod telemetry;
 pub mod tools;
 pub mod update;
 pub mod upgrade;
+pub mod watchdog;
 
 pub use error::{Error, Result};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2097,6 +2097,37 @@ async fn run(
         }
     }
 
+    // Startup catch-up: scan for issues missed during downtime.
+    // Runs as a background task so it doesn't block the main event loop.
+    if agents_initialized {
+        let catchup_injection_tx = injection_tx.clone();
+        let catchup_agents: Vec<_> = agents
+            .iter()
+            .map(|(id, a)| (id.to_string(), a.deps.registry_store.clone()))
+            .collect();
+        tokio::spawn(async move {
+            // Small delay to let the main loop start accepting messages first
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            for (agent_id, registry_store) in &catchup_agents {
+                spacebot::watchdog::run_startup_catchup(
+                    agent_id,
+                    registry_store,
+                    &catchup_injection_tx,
+                )
+                .await;
+            }
+        });
+    }
+
+    // Health watchdog: exit if no messages are processed for 10 minutes.
+    // systemd will restart the service automatically.
+    let watchdog = spacebot::watchdog::spawn_watchdog(
+        std::time::Duration::from_secs(600),  // 10 minute timeout
+        std::time::Duration::from_secs(60),    // check every minute
+    );
+    // Ping immediately so the watchdog doesn't trigger during initial quiet period
+    watchdog.ping();
+
     // Main event loop: route inbound messages to agent channels
     loop {
         // Poll the inbound stream if it exists, otherwise yield a never-resolving future
@@ -2319,6 +2350,8 @@ async fn run(
                             "failed to forward message to channel"
                         );
                         active_channels.remove(&conversation_id);
+                    } else {
+                        watchdog.ping();
                     }
                 }
             }
@@ -2347,6 +2380,7 @@ async fn run(
                             "failed to forward injected message to channel"
                         );
                     } else {
+                        watchdog.ping();
                         tracing::info!(
                             conversation_id = %injection.conversation_id,
                             agent_id = %injection.agent_id,
@@ -2354,6 +2388,10 @@ async fn run(
                         );
                     }
                 } else {
+                    // No active channel — the catch-up message will be routed
+                    // when the next inbound message creates the channel.
+                    // Still ping watchdog since we're processing events.
+                    watchdog.ping();
                     tracing::info!(
                         conversation_id = %injection.conversation_id,
                         agent_id = %injection.agent_id,

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -143,10 +143,8 @@ pub fn build_release(
     // Cargo writes progress to stderr
     let stderr = child.stderr.take().unwrap();
     let reader = BufReader::new(stderr);
-    for line in reader.lines() {
-        if let Ok(line) = line {
-            on_line(&line);
-        }
+    for line in reader.lines().map_while(Result::ok) {
+        on_line(&line);
     }
 
     let status = child.wait()?;

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,317 @@
+//! Startup catch-up and health watchdog.
+//!
+//! - **Catch-up**: After boot, scans enabled repos for open issues that were
+//!   missed during downtime (no `prd-generated` label) and injects synthetic
+//!   webhook messages so the agent processes them.
+//!
+//! - **Watchdog**: Periodically checks whether the daemon is still processing
+//!   messages. If no activity is observed for a configurable timeout, the
+//!   process exits so systemd can restart it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+
+use crate::registry::RegistryStore;
+use crate::{InboundMessage, MessageContent};
+
+// ---------------------------------------------------------------------------
+// Startup catch-up
+// ---------------------------------------------------------------------------
+
+/// Issue metadata returned by `gh issue list --json`.
+#[derive(Debug, serde::Deserialize)]
+struct GhIssue {
+    number: u64,
+    title: String,
+    body: Option<String>,
+    labels: Vec<GhLabel>,
+    #[serde(rename = "createdAt")]
+    #[allow(dead_code)]
+    created_at: String,
+    author: Option<GhAuthor>,
+    url: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GhAuthor {
+    login: String,
+}
+
+/// Scan all enabled repos for the given agent and inject synthetic
+/// `issues.opened` messages for any open issues that lack the
+/// `prd-generated` label (i.e. were missed during downtime).
+///
+/// Only considers issues created in the last 24 hours to avoid
+/// re-processing ancient issues on first deploy.
+pub async fn run_startup_catchup(
+    agent_id: &str,
+    registry_store: &Arc<RegistryStore>,
+    injection_tx: &mpsc::Sender<crate::ChannelInjection>,
+) {
+    let repos = match registry_store.list_repos(agent_id, true).await {
+        Ok(repos) => repos,
+        Err(error) => {
+            tracing::warn!(%error, "startup catch-up: failed to list repos");
+            return;
+        }
+    };
+
+    if repos.is_empty() {
+        tracing::debug!("startup catch-up: no enabled repos, skipping");
+        return;
+    }
+
+    let mut total_injected = 0u32;
+
+    for repo in &repos {
+        let full_name = &repo.full_name;
+        let issues = match discover_unprocessed_issues(full_name).await {
+            Ok(issues) => issues,
+            Err(error) => {
+                tracing::warn!(
+                    repo = %full_name,
+                    %error,
+                    "startup catch-up: failed to query issues"
+                );
+                continue;
+            }
+        };
+
+        for issue in &issues {
+            let author = issue
+                .author
+                .as_ref()
+                .map(|a| a.login.as_str())
+                .unwrap_or("unknown");
+
+            let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
+            let labels_str = if labels.is_empty() {
+                "none".to_string()
+            } else {
+                labels.join(", ")
+            };
+
+            let body_preview = issue
+                .body
+                .as_deref()
+                .unwrap_or("")
+                .chars()
+                .take(500)
+                .collect::<String>();
+
+            let content = format!(
+                "GitHub webhook: issues.opened\n\
+                 Repo: {full_name}\n\
+                 Issue #{number}: {title}\n\
+                 Author: {author}\n\
+                 Labels: {labels_str}\n\
+                 URL: {url}\n\
+                 Body:\n{body}",
+                number = issue.number,
+                title = issue.title,
+                url = issue.url,
+                body = body_preview,
+            );
+
+            let conversation_id = format!("webhook:github:{full_name}");
+
+            let mut metadata = HashMap::new();
+            metadata.insert(
+                "webhook_conversation_id".into(),
+                serde_json::Value::String(format!("github:{full_name}")),
+            );
+            metadata.insert(
+                "display_name".into(),
+                serde_json::Value::String("github-webhook".into()),
+            );
+            metadata.insert(
+                "sender_display_name".into(),
+                serde_json::Value::String("github-webhook".into()),
+            );
+            metadata.insert(
+                crate::metadata_keys::CHANNEL_NAME.into(),
+                serde_json::Value::String(format!("github:{full_name}")),
+            );
+            metadata.insert(
+                "startup_catchup".into(),
+                serde_json::Value::Bool(true),
+            );
+
+            let message = InboundMessage {
+                id: uuid::Uuid::new_v4().to_string(),
+                source: "webhook".into(),
+                adapter: Some("webhook".into()),
+                conversation_id: conversation_id.clone(),
+                sender_id: "github-webhook".into(),
+                agent_id: Some(Arc::from(agent_id)),
+                content: MessageContent::Text(content),
+                timestamp: chrono::Utc::now(),
+                metadata,
+                formatted_author: Some("github-webhook".into()),
+            };
+
+            let injection = crate::ChannelInjection {
+                conversation_id,
+                agent_id: agent_id.to_string(),
+                message,
+            };
+
+            if let Err(error) = injection_tx.send(injection).await {
+                tracing::warn!(
+                    repo = %full_name,
+                    issue = issue.number,
+                    %error,
+                    "startup catch-up: failed to inject issue"
+                );
+            } else {
+                tracing::info!(
+                    repo = %full_name,
+                    issue = issue.number,
+                    title = %issue.title,
+                    "startup catch-up: injected missed issue"
+                );
+                total_injected += 1;
+            }
+        }
+    }
+
+    if total_injected > 0 {
+        tracing::info!(
+            count = total_injected,
+            "startup catch-up complete: injected missed issues"
+        );
+    } else {
+        tracing::info!("startup catch-up complete: no missed issues found");
+    }
+}
+
+/// Query GitHub for open issues on `repo` that do NOT have the
+/// `prd-generated` label and were created in the last 24 hours.
+async fn discover_unprocessed_issues(repo: &str) -> anyhow::Result<Vec<GhIssue>> {
+    let since = (chrono::Utc::now() - chrono::Duration::hours(24))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    // gh issue list with search query: no prd-generated label, created since cutoff
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            &format!("-label:prd-generated created:>{since}"),
+            "--json",
+            "number,title,body,labels,createdAt,author,url",
+            "--limit",
+            "20",
+        ])
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to run gh: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh issue list failed: {stderr}");
+    }
+
+    let issues: Vec<GhIssue> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| anyhow::anyhow!("failed to parse gh output: {e}"))?;
+
+    Ok(issues)
+}
+
+// ---------------------------------------------------------------------------
+// Health watchdog
+// ---------------------------------------------------------------------------
+
+/// Spawn a background task that monitors message processing activity.
+///
+/// If no messages are processed for `timeout` duration, the process exits
+/// with code 1 so systemd can restart it. The watchdog checks every
+/// `check_interval`.
+///
+/// Returns a handle that should be used to report activity via
+/// `WatchdogHandle::ping()`.
+pub fn spawn_watchdog(timeout: Duration, check_interval: Duration) -> WatchdogHandle {
+    let last_activity = Arc::new(std::sync::atomic::AtomicU64::new(
+        instant_to_epoch_secs(Instant::now()),
+    ));
+
+    let handle = WatchdogHandle {
+        last_activity: last_activity.clone(),
+    };
+
+    tokio::spawn(async move {
+        tracing::info!(
+            timeout_secs = timeout.as_secs(),
+            check_interval_secs = check_interval.as_secs(),
+            "health watchdog started"
+        );
+
+        loop {
+            tokio::time::sleep(check_interval).await;
+
+            let last = last_activity.load(std::sync::atomic::Ordering::Relaxed);
+            let now = instant_to_epoch_secs(Instant::now());
+            let elapsed = Duration::from_secs(now.saturating_sub(last));
+
+            if elapsed > timeout {
+                tracing::error!(
+                    elapsed_secs = elapsed.as_secs(),
+                    timeout_secs = timeout.as_secs(),
+                    "health watchdog: no activity detected, exiting for restart"
+                );
+                // Give tracing a moment to flush
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                std::process::exit(1);
+            } else {
+                tracing::debug!(
+                    elapsed_secs = elapsed.as_secs(),
+                    "health watchdog: activity detected, all good"
+                );
+            }
+        }
+    });
+
+    handle
+}
+
+/// Handle for reporting activity to the watchdog.
+#[derive(Clone)]
+pub struct WatchdogHandle {
+    last_activity: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl WatchdogHandle {
+    /// Report that a message was processed, resetting the watchdog timer.
+    pub fn ping(&self) {
+        self.last_activity.store(
+            instant_to_epoch_secs(Instant::now()),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+}
+
+/// Convert an `Instant` to a monotonic epoch-seconds value.
+/// Uses `Instant::now().elapsed()` trick to get a stable u64 for atomic ops.
+fn instant_to_epoch_secs(instant: Instant) -> u64 {
+    // We use system time here since Instant doesn't expose raw values.
+    // This is fine — we only compare deltas, not absolute values.
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        // Adjust for the difference between `instant` and `Instant::now()`
+        .wrapping_sub(Instant::now().duration_since(instant).as_secs())
+}


### PR DESCRIPTION
## Summary
- **Startup catch-up**: On boot, scans all enabled repos for open issues created in the last 24h that lack the `prd-generated` label. Injects them as synthetic webhook messages so missed issues (from downtime or freezes) get processed automatically.
- **Health watchdog**: Background task monitors message processing. If no activity for 10 minutes, exits with code 1 so systemd restarts the service. Prevents silent freezes from going undetected.

## Why
Spacebot can freeze silently (channel deadlock after worker API errors), causing webhook events to be accepted but never processed. Issues created during downtime or freezes are permanently lost since webhooks are fire-and-forget.

## Changes
- New `src/watchdog.rs` module with both features
- Catch-up runs as background task 5s after boot (doesn't block main loop)
- Watchdog pings on every successfully forwarded message (inbound + injected)
- Uses `gh issue list` CLI for issue discovery (no new API dependencies)

## Test plan
- [ ] Build passes (`cargo build --release`)
- [ ] Restart spacebot and verify catch-up logs appear (`journalctl --user -u spacebot`)
- [ ] Create a test issue, restart spacebot, verify it gets picked up
- [ ] Verify watchdog doesn't false-trigger during normal operation (10min timeout, 1min check interval)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)