### PR TITLE
fix: resolve compilation and formatting errors on main

### DIFF
--- a/tests/opencode_stream.rs
+++ b/tests/opencode_stream.rs
@@ -189,12 +189,12 @@ async fn stream_events_from_live_server() {
                         saw_text = true;
                     }
                 }
-                SseEvent::SessionIdle { session_id: sid } => {
-                    if sid == &session_id && saw_assistant {
-                        saw_idle = true;
-                        events.push(event);
-                        break;
-                    }
+                SseEvent::SessionIdle { session_id: sid }
+                    if sid == &session_id && saw_assistant =>
+                {
+                    saw_idle = true;
+                    events.push(event);
+                    break;
                 }
                 _ => {}
             }


### PR DESCRIPTION
Fixes clippy lint errors that were preventing CI from passing on the main branch.

## Changes
- Collapsed nested if statement into match guard in opencode_stream.rs test
- All cargo clippy checks now pass with zero errors
- All cargo fmt checks now pass

## Verification
- ✅ cargo check --all-targets --all-features
- ✅ cargo clippy --all-targets --all-features  
- ✅ cargo fmt --all --check