### PR TITLE
fix(watchdog): count autonomous worker/cortex activity as liveness

### DIFF
--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -1000,6 +1000,11 @@ where
     M: CompletionModel,
 {
     async fn on_completion_call(&self, _prompt: &Message, _history: &[Message]) -> HookAction {
+        // Every LLM turn (worker or cortex-chat) is genuine daemon activity:
+        // keep the health watchdog satisfied even when no inbound platform
+        // message is arriving (autonomous deployments).
+        crate::watchdog::note_activity();
+
         if self.tool_nudge_policy.is_enabled() {
             self.completion_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1282,6 +1287,11 @@ where
         _args: &str,
         result: &str,
     ) -> HookAction {
+        // A returning tool result is genuine work — bound long single turns
+        // (e.g. slow shell/browser tools) so they also keep the watchdog
+        // satisfied between completion calls.
+        crate::watchdog::note_activity();
+
         if tool_name == "reply"
             && let Ok(mut guard) = self.reply_tool_delta_state.lock()
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2367,11 +2367,19 @@ async fn run(
         });
     }
 
-    // Health watchdog: exit if no messages are processed for 10 minutes.
-    // systemd will restart the service automatically.
+    // Health watchdog: exit if no activity — inbound messages OR autonomous
+    // worker/cortex work (see watchdog::note_activity) — is observed for the
+    // timeout window; the supervisor (systemd / Docker) then restarts us.
+    // Configurable via SPACEBOT_WATCHDOG_TIMEOUT_SECS (default 600s; `0`
+    // disables the killer for autonomous deployments that should never
+    // self-restart).
+    let watchdog_timeout_secs = std::env::var("SPACEBOT_WATCHDOG_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(600);
     let watchdog = spacebot::watchdog::spawn_watchdog(
-        std::time::Duration::from_secs(600), // 10 minute timeout
-        std::time::Duration::from_secs(60),  // check every minute
+        std::time::Duration::from_secs(watchdog_timeout_secs),
+        std::time::Duration::from_secs(60), // check every minute
     );
     // Ping immediately so the watchdog doesn't trigger during initial quiet period
     watchdog.ping();

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -9,7 +9,7 @@
 //!   process exits so systemd can restart it.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc;
@@ -232,11 +232,44 @@ async fn discover_unprocessed_issues(repo: &str) -> anyhow::Result<Vec<GhIssue>>
 // Health watchdog
 // ---------------------------------------------------------------------------
 
-/// Spawn a background task that monitors message processing activity.
+/// Process-global activity timestamp, shared with the watchdog loop.
 ///
-/// If no messages are processed for `timeout` duration, the process exits
-/// with code 1 so systemd can restart it. The watchdog checks every
-/// `check_interval`.
+/// `spawn_watchdog` registers the same `Arc<AtomicU64>` it watches here so
+/// that *any* code path representing the daemon doing real work — not just
+/// the inbound-message router — can keep the watchdog satisfied via
+/// [`note_activity`]. This is what makes the watchdog correct on autonomous
+/// deployments (GitHub-issue/PR automation, cortex loops) that rarely or
+/// never receive an inbound platform message.
+static GLOBAL_ACTIVITY: OnceLock<Arc<std::sync::atomic::AtomicU64>> = OnceLock::new();
+
+/// Report autonomous activity (an LLM turn, a tool result, a cortex tick) to
+/// the health watchdog, resetting its timer exactly like an inbound message
+/// would. No-op until `spawn_watchdog` has registered the global timestamp,
+/// and a cheap relaxed atomic store otherwise — safe to call on hot paths.
+///
+/// Pinging only on *genuine work* (rather than from a bare timer loop) is
+/// deliberate: it keeps the watchdog able to detect a truly wedged daemon
+/// while preventing false restarts of a busy-but-quiet autonomous instance.
+pub fn note_activity() {
+    if let Some(last_activity) = GLOBAL_ACTIVITY.get() {
+        last_activity.store(
+            instant_to_epoch_secs(Instant::now()),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+}
+
+/// Spawn a background task that monitors daemon activity.
+///
+/// Activity is reported both by the inbound-message router (via
+/// [`WatchdogHandle::ping`]) and by autonomous work (via [`note_activity`]).
+/// If no activity is observed for `timeout`, the process exits with code 1
+/// so the supervisor (systemd / Docker `restart: unless-stopped`) restarts
+/// it. The watchdog checks every `check_interval`.
+///
+/// A `timeout` of zero **disables** the killer entirely (for autonomous
+/// deployments that should never self-restart); the returned handle and
+/// [`note_activity`] remain valid no-ops so callers need no special-casing.
 ///
 /// Returns a handle that should be used to report activity via
 /// `WatchdogHandle::ping()`.
@@ -245,9 +278,19 @@ pub fn spawn_watchdog(timeout: Duration, check_interval: Duration) -> WatchdogHa
         Instant::now(),
     )));
 
+    // Register the shared timestamp so `note_activity()` feeds the same value
+    // this loop watches. `set` only fails if called twice; the watchdog is
+    // spawned exactly once, so a failure is benign and ignored.
+    let _ = GLOBAL_ACTIVITY.set(last_activity.clone());
+
     let handle = WatchdogHandle {
         last_activity: last_activity.clone(),
     };
+
+    if timeout.is_zero() {
+        tracing::info!("health watchdog disabled (timeout = 0)");
+        return handle;
+    }
 
     tokio::spawn(async move {
         tracing::info!(


### PR DESCRIPTION
## Problem

The in-process health watchdog only reset its timer on **inbound-message routing** (`WatchdogHandle::ping()` at the four main-loop sites). Worker LLM turns, tool execution, and cortex loops never reset it.

On an **autonomous** deployment (GitHub issue/PR automation, ~0 inbound messages) the 600s timer therefore always elapsed and the daemon `process::exit(1)`'d every ~11 minutes (RestartCount 114+/day on lira). Each restart kills in-flight workers mid-task — they are reconciled to `failed` on startup and not resumed — so an agent posts *"Investigating"* and then dies silently with no PR. Proven live: worker `eb2df24c` was mid-edit on a fix when the watchdog fired at `elapsed_secs=658`; restart logged `orphaned_workers=1`.

Root cause of marcmantei/shipyard#46 and marcmantei/shipyard#56.

## Fix

- **`watchdog::note_activity()`** — a process-global activity timestamp (`OnceLock<Arc<AtomicU64>>`) shared with the watchdog loop. Wired into `SpacebotHook::on_completion_call` (every LLM turn) and `on_tool_result` (every tool result), so worker + cortex-chat activity keeps the watchdog satisfied. Pinging only on *genuine work* (not a bare timer) preserves the ability to detect a truly wedged daemon.
- **Configurable timeout** via `SPACEBOT_WATCHDOG_TIMEOUT_SECS` (default 600; `0` disables the killer for autonomous deployments). Implements #46 option 2.

## Follow-up (separate PR)

Resume/re-enqueue interrupted **running** task workers on restart instead of dropping them — so even a legitimate restart never silently loses work.

Refs marcmantei/shipyard#46, marcmantei/shipyard#56