### PR TITLE
fix(worker): flush token usage from a single exit, not the success path (#33)

### DIFF
--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -535,12 +535,42 @@ impl Worker {
         let worker_id = self.id;
         let agent_id = self.deps.agent_id.clone();
 
-        let inner_handle = tokio::spawn(self.run_inner());
+        // Token usage is accumulated here, not inside `run_inner`, so that the
+        // flush below can reach it on EVERY exit (#33).
+        //
+        // It used to be created in `run_inner` and flushed on the success path
+        // only, which lost the cost of every other ending:
+        //
+        //   * `Failed` / `Blocked` returned early, before the flush
+        //   * a wall-clock timeout aborts the inner task from the `select!`
+        //     below — nothing inside it ever runs again
+        //   * a kill or panic takes the in-memory accumulator with it
+        //
+        // Measured on 2026-08-04: 21 workers ran, 4 wrote a row. The two most
+        // expensive runs of the day — 45m/202 tool calls and 1h59m/130 tool
+        // calls — both recorded $0, because both died. Cost reporting therefore
+        // hid exactly the failures worth seeing, and a thrashing loop looked
+        // *cheaper* than a working one.
+        //
+        // Note both early returns already call `persist_transcript`: the
+        // transcript was considered worth keeping on failure, the cost was not.
+        let usage_accumulator = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::llm::usage::UsageAccumulator::new(),
+        ));
+        // Cloned before `self` is moved into the spawned task.
+        let flush_pool = self.deps.sqlite_pool.clone();
+        let flush_agent_id = self.deps.agent_id.clone();
+        let flush_channel_id = self.channel_id.clone();
+
+        let inner_handle = tokio::spawn(self.run_inner(usage_accumulator.clone()));
         // Abort the inner task if `run` returns (timeout / completion) OR is
         // dropped (external `handle.abort()` on run's task) — never detach it.
         let _abort_inner = AbortOnDrop(inner_handle.abort_handle());
 
-        tokio::select! {
+        // A panic is re-raised rather than returned, so it cannot go through
+        // the shared flush below — flush before unwinding instead. Everything
+        // else falls through to the single flush after the `select!`.
+        let outcome = tokio::select! {
             joined = inner_handle => match joined {
                 Ok(outcome) => outcome,
                 Err(join_err) if join_err.is_cancelled() => Ok(WorkerOutcome::Cancelled {
@@ -548,7 +578,14 @@ impl Worker {
                 }),
                 // Re-raise an inner panic so `spawn_worker_task`'s `catch_unwind`
                 // records it as a failure exactly as it did before this change.
-                Err(join_err) => std::panic::resume_unwind(join_err.into_panic()),
+                Err(join_err) => {
+                    Self::flush_usage(
+                        &usage_accumulator, &flush_pool, &flush_agent_id,
+                        flush_channel_id.as_deref(),
+                    )
+                    .await;
+                    std::panic::resume_unwind(join_err.into_panic())
+                }
             },
             _ = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)) => {
                 let segments = segments_tracker.load(std::sync::atomic::Ordering::Relaxed);
@@ -564,6 +601,41 @@ impl Worker {
                     segments_run: segments,
                 })
             }
+        };
+
+        // The single exit. Whatever the worker did — finished, failed, was
+        // blocked, timed out, or was cancelled — its spend is recorded here.
+        Self::flush_usage(
+            &usage_accumulator, &flush_pool, &flush_agent_id,
+            flush_channel_id.as_deref(),
+        )
+        .await;
+
+        outcome
+    }
+
+    /// Persist whatever the worker spent. Idempotent and never fatal.
+    ///
+    /// `UsageAccumulator::flush` no-ops when nothing was accumulated, so the
+    /// timeout branch calling this after the inner task already flushed cannot
+    /// double-count — `take()` empties the accumulator as it reads it.
+    ///
+    /// A failure here is logged, never propagated: losing the cost record is
+    /// bad, failing the worker over it is worse.
+    async fn flush_usage(
+        accumulator: &std::sync::Arc<tokio::sync::Mutex<crate::llm::usage::UsageAccumulator>>,
+        pool: &sqlx::SqlitePool,
+        agent_id: &str,
+        channel_id: Option<&str>,
+    ) {
+        let mut acc = accumulator.lock().await;
+        let pending = acc.take();
+        drop(acc);
+        if !pending.has_usage() {
+            return;
+        }
+        if let Err(error) = pending.flush(pool, agent_id, "worker", channel_id).await {
+            tracing::warn!(%error, "failed to flush worker token usage");
         }
     }
 
@@ -573,7 +645,10 @@ impl Worker {
     /// and compacts if the worker is approaching the context window limit.
     /// This prevents long-running workers from dying mid-task due to context
     /// exhaustion.
-    async fn run_inner(mut self) -> Result<WorkerOutcome> {
+    async fn run_inner(
+        mut self,
+        usage_accumulator: std::sync::Arc<tokio::sync::Mutex<crate::llm::usage::UsageAccumulator>>,
+    ) -> Result<WorkerOutcome> {
         // Wire the injection receiver into the hook so `on_completion_call`
         // can drain pending injected context before each LLM turn.
         if let Some(inject_rx) = self.inject_rx.take() {
@@ -621,9 +696,9 @@ impl Worker {
             .as_deref()
             .unwrap_or_else(|| routing.resolve(ProcessType::Worker, None))
             .to_string();
-        let usage_accumulator = std::sync::Arc::new(tokio::sync::Mutex::new(
-            crate::llm::usage::UsageAccumulator::new(),
-        ));
+        // The accumulator is owned by `run`, which flushes it from a single
+        // exit every ending passes through (#33). Creating one here again
+        // would make the model write into an accumulator nothing ever reads.
         let model = SpacebotModel::make(&self.deps.llm_manager, &model_name)
             .with_context(&*self.deps.agent_id, "worker")
             .with_worker_type("builtin")
@@ -1082,19 +1157,10 @@ impl Worker {
         // Persist transcript blob
         self.persist_transcript(&compacted_history, &history).await;
 
-        // Flush accumulated token usage.
-        let acc = usage_accumulator.lock().await;
-        if let Err(error) = acc
-            .flush(
-                &self.deps.sqlite_pool,
-                &self.deps.agent_id,
-                "worker",
-                self.channel_id.as_deref(),
-            )
-            .await
-        {
-            tracing::warn!(%error, "failed to flush worker token usage");
-        }
+        // Token usage is NOT flushed here. `run` flushes from a single exit
+        // that every ending reaches, so the success path needs no special
+        // case — and adding one back here would be the bug this fixed (#33):
+        // whoever adds the next early return would have to remember to copy it.
 
         tracing::info!(worker_id = %self.id, "worker completed");
         if hit_max_segments {

--- a/src/llm/usage.rs
+++ b/src/llm/usage.rs
@@ -126,6 +126,20 @@ impl UsageAccumulator {
         Self::default()
     }
 
+    /// Move the accumulated usage out, leaving this accumulator empty.
+    ///
+    /// Makes flushing safe to attempt more than once (#33). The worker now
+    /// flushes from a single exit point that every ending passes through, and
+    /// the timeout branch can race an inner task that already flushed —
+    /// draining on read means the second attempt finds nothing rather than
+    /// writing the same tokens twice.
+    ///
+    /// A worker that flushes incrementally later gets the same property for
+    /// free: each flush persists only what accrued since the last one.
+    pub fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+
     /// Record one API call's usage.
     pub fn add(&mut self, usage: ExtendedUsage, model: &str, provider: &str, cost: f64) {
         self.input_tokens += usage.input_tokens;
@@ -310,5 +324,102 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 300);
         assert_eq!(usage.cache_write_tokens, 200);
         assert_eq!(usage.reasoning_tokens, 100);
+    }
+
+    // ── take(): the double-count guard for the single-exit flush (#33) ──────
+
+    fn sample(model: &str) -> (ExtendedUsage, &str, &str, f64) {
+        (
+            ExtendedUsage {
+                input_tokens: 1000,
+                output_tokens: 500,
+                cache_read_tokens: 200,
+                cache_write_tokens: 100,
+                reasoning_tokens: 50,
+            },
+            model,
+            "anthropic",
+            0.25,
+        )
+    }
+
+    #[test]
+    fn test_take_moves_the_usage_out() {
+        let mut acc = UsageAccumulator::new();
+        let (usage, model, provider, cost) = sample("claude-sonnet-5");
+        acc.add(usage, model, provider, cost);
+
+        let taken = acc.take();
+
+        // Everything that was accumulated comes out...
+        assert_eq!(taken.input_tokens, 1000);
+        assert_eq!(taken.output_tokens, 500);
+        assert_eq!(taken.request_count, 1);
+        assert!(taken.has_usage());
+        // ...and the accumulator is left empty.
+        assert_eq!(acc.input_tokens, 0);
+        assert_eq!(acc.request_count, 0);
+        assert!(!acc.has_usage());
+    }
+
+    #[test]
+    fn test_take_twice_yields_nothing_the_second_time() {
+        // The property the single-exit flush relies on: `run` flushes after the
+        // `select!`, and the timeout branch can race an inner task that already
+        // flushed. Draining on read means the loser writes nothing rather than
+        // writing the same tokens a second time.
+        let mut acc = UsageAccumulator::new();
+        let (usage, model, provider, cost) = sample("claude-sonnet-5");
+        acc.add(usage, model, provider, cost);
+
+        let first = acc.take();
+        let second = acc.take();
+
+        assert!(first.has_usage());
+        assert!(!second.has_usage(), "a second flush must find nothing to write");
+        assert_eq!(second.request_count, 0);
+        assert_eq!(second.input_tokens, 0);
+    }
+
+    #[test]
+    fn test_take_preserves_the_total_across_incremental_flushes() {
+        // Whatever the split, the sum of what is written equals what was spent
+        // — no tokens lost between flushes, none counted twice.
+        let mut acc = UsageAccumulator::new();
+        let (usage, model, provider, cost) = sample("claude-sonnet-5");
+
+        acc.add(usage, model, provider, cost);
+        acc.add(usage, model, provider, cost);
+        let first = acc.take(); // an incremental flush mid-run
+
+        acc.add(usage, model, provider, cost);
+        let second = acc.take(); // the terminal flush
+
+        assert_eq!(first.request_count + second.request_count, 3);
+        assert_eq!(first.input_tokens + second.input_tokens, 3000);
+        assert_eq!(first.output_tokens + second.output_tokens, 1500);
+    }
+
+    #[test]
+    fn test_take_on_an_empty_accumulator_is_harmless() {
+        // A worker that died before its first LLM call still reaches the flush.
+        let mut acc = UsageAccumulator::new();
+        let taken = acc.take();
+        assert!(!taken.has_usage(), "nothing accumulated, nothing to flush");
+    }
+
+    #[test]
+    fn test_take_carries_the_model_and_provider() {
+        // flush() derives the `model` column from these — a taken accumulator
+        // must still know which model it was, or the row lands as "unknown".
+        let mut acc = UsageAccumulator::new();
+        let (usage, _, provider, cost) = sample("x");
+        acc.add(usage, "claude-opus-5", provider, cost);
+        acc.add(usage, "claude-opus-5", provider, cost);
+        acc.add(usage, "claude-haiku-4-5", provider, cost);
+
+        let taken = acc.take();
+        assert_eq!(taken.primary_model(), "claude-opus-5");
+        assert_eq!(taken.provider.as_deref(), Some("anthropic"));
     }
 }


### PR DESCRIPTION
Closes #33.

## The problem

Worker spend was recorded only when a worker succeeded. Measured 2026-08-04: **21 workers ran, 4 wrote a row**. The two most expensive runs of the day — 45m/202 tool calls and 1h59m/130 tool calls — both recorded **$0**, because both died.

That inverts cost reporting exactly where it matters: a loop that thrashes and dies looks *cheaper* than one that works.

## Why the old placement could not hold

`acc.flush(...)` sat at the end of `run_inner`, after the success path's `self.state = WorkerState::Done`:

| Ending | Flushed? |
|---|---|
| `Done` | yes |
| `Failed` | **no** — early return above the flush |
| `Blocked` | **no** — early return above the flush |
| wall-clock timeout | **no** — `run`'s `select!` aborts the inner task; nothing in it runs again |
| kill / panic | **no** — in-memory accumulator dies with the process |

Both early returns already call `persist_transcript`. The transcript was considered worth keeping on failure; the cost was not. That asymmetry is the bug in one line.

The timeout path is worse than the issue described: `AbortOnDrop` kills the inner task, so that ending could *never* have flushed, no matter where inside `run_inner` the call sat.

## The fix

Copying the flush into each `return` would leave five terminal paths to keep in sync, and whoever adds the sixth has to remember. Instead the accumulator moves up to `run`, which already owns the one exit every ending passes through — the `select!`. `run_inner` receives it and no longer flushes at all, so there is no success-path special case left to diverge from.

A panic is re-raised rather than returned, so it gets an explicit flush before unwinding.

## Double-counting

Guarded by `UsageAccumulator::take()`, which drains as it reads. The timeout branch can race an inner task that already flushed; the loser finds an empty accumulator and writes nothing.

The same property makes **incremental flushing safe for free** — each flush persists only what accrued since the last one. This PR does not add incremental flushing (a kill still loses the current run's tokens), but it removes the obstacle: that is now an additive change, not a redesign.

A flush failure is logged, never propagated. Losing the cost record is bad; failing the worker over it is worse.

## Tests

Five new cases pin `take()`: drains on read, a second take is empty, split flushes sum to the true total, an empty accumulator is harmless, model/provider survive the move.

`cargo test --lib` on this branch: **890 passed, 14 failed**.
`cargo test --lib` on `main`, unchanged: **885 passed, 14 failed**.

Same 14 failures (`registry::store` and siblings) — pre-existing on `main`, unrelated to this change. Worth its own ticket.

## Verification after deploy

Force a worker failure, then check a row appears:

```sh
docker exec airflow-worker python -c "
import sqlite3
con=sqlite3.connect('file:/data/spacebot-data/agents/main/data/agent.db?mode=ro',uri=True)
for r in con.execute(\"select conversation_id,request_count,recorded_at from token_usage where process_type='worker' order by recorded_at desc limit 5\"): print(r)
"
```

Then compare distinct workers run against rows written over the same window — they should now agree.

## Out of scope

Recording the outcome alongside the usage (so failed spend is queryable separately) and incremental flushing. Both are additive on top of this and worth doing; keeping them out keeps this diff about the one asymmetry that loses the data.