### PR TITLE
feat(llm): default xAI routing to Grok 4.5 and seed pricing

### DIFF
--- a/src/llm/pricing.rs
+++ b/src/llm/pricing.rs
@@ -34,6 +34,41 @@ fn lookup_pricing(model_name: &str) -> ModelPricing {
     // Prices verified 2026-07-29 against platform.claude.com pricing docs
     // (Claude Opus 5 confirmed $5/$25 — same tier as Opus 4.5+).
     match model {
+        // xAI Grok — rates from docs.x.ai (2026-08-07, <200k prompt tier).
+        // Longest / most specific prefixes first.
+        m if m.starts_with("grok-4.5") => ModelPricing {
+            input: per_m(2.0),
+            output: per_m(6.0),
+            cached_input: per_m(0.30),
+            cache_write: per_m(2.0),
+        },
+        m if m.starts_with("grok-4.3") => ModelPricing {
+            input: per_m(1.25),
+            output: per_m(2.5),
+            cached_input: per_m(0.20),
+            cache_write: per_m(1.25),
+        },
+        m if m.starts_with("grok-4.20") => ModelPricing {
+            input: per_m(1.25),
+            output: per_m(2.5),
+            cached_input: per_m(0.20),
+            cache_write: per_m(1.25),
+        },
+        m if m.starts_with("grok-build-0.1") => ModelPricing {
+            input: per_m(1.0),
+            output: per_m(2.0),
+            cached_input: per_m(0.20),
+            cache_write: per_m(1.0),
+        },
+        m if m.starts_with("grok-4") || m.starts_with("grok-2") || m.starts_with("grok-3") => {
+            ModelPricing {
+                input: per_m(3.0),
+                output: per_m(15.0),
+                cached_input: per_m(0.75),
+                cache_write: per_m(3.0),
+            }
+        }
+
         m if m.starts_with("claude-fable-5") || m.starts_with("claude-mythos-5") => {
             ModelPricing {
                 input: per_m(10.0),

--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -316,8 +316,11 @@ pub fn defaults_for_provider(provider: &str) -> RoutingConfig {
             }
         }
         "xai" => {
-            let channel: String = "xai/grok-2-latest".into();
-            let worker: String = "xai/grok-2-latest".into();
+            // Grok 4.5 is the flagship (coding + judgment). Channel/branch share
+            // the flagship; cortex/compactor can stay on the same id until a
+            // cheaper tier is profiled for those roles.
+            let channel: String = "xai/grok-4.5".into();
+            let worker: String = "xai/grok-4.5".into();
             RoutingConfig {
                 channel: channel.clone(),
                 branch: channel.clone(),


### PR DESCRIPTION
## Summary

- xAI onboarding `RoutingConfig` defaults: `xai/grok-2-latest` → **`xai/grok-4.5`**
- Official Grok 4.5 / 4.3 / 4.20 rates in `pricing.rs` for token_usage cost estimates

**Fork-only** for the lira Shipyard fleet cutover (pairs with marcmantei/shipyard#521). Not intended for spacedriveapp/spacebot upstream.

## Test plan

- [ ] Deploy/rebuild spacebot on lira with this branch
- [ ] With `XAI_API_KEY`, routing uses `xai/grok-4.5`
- [ ] Cost estimates for grok-4.5 match ~$2/$6 per MTok